### PR TITLE
(feat) use image.url if no IMAGE_SERVICE_URL is given

### DIFF
--- a/helpers/images.js
+++ b/helpers/images.js
@@ -56,9 +56,13 @@ function getImagesForWidth(variants, width) {
 }
 
 function getImageUrlForWidthAndFormat(image, width, format) {
-  return process.env.IMAGE_SERVICE_URL.replace("{key}", image.key)
-    .replace("{width}", width)
-    .replace("{format}", format);
+  if (process.env.IMAGE_SERVICE_URL) {
+    return process.env.IMAGE_SERVICE_URL.replace("{key}", image.key)
+      .replace("{width}", width)
+      .replace("{format}", format);
+  } else {
+    return image.url;
+  }
 }
 
 function getImageWithUrlsForImageAndWidth(image, width, serveLosslessWebP) {

--- a/routes/rendering-info/web-image-inlined.js
+++ b/routes/rendering-info/web-image-inlined.js
@@ -56,7 +56,6 @@ module.exports = {
       )}`.replace(/-/g, "")
     };
 
-    const imageServiceUrl = process.env.IMAGE_SERVICE_URL;
     const images = imageHelpers.getImagesForWidth(item.images.variants, width);
 
     // fetch the image via imageService in the correct width with assumed dpr of 2 for the screenshot


### PR DESCRIPTION
- this uses the `image.url` directly if no IMAGE_SERVICE_URL is given
- this allows for easier local development using fixture data
- deployed on test with the IMAGE_SERVICE_URL env var removed
- for testing: observe that the image gets loaded directly from S3 not via image service